### PR TITLE
save outputs

### DIFF
--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -122,6 +122,9 @@ class BashKernel(Kernel):
             stream_content = {'name': 'stdout', 'text': output}
             self.send_response(self.iopub_socket, 'stream', stream_content)
 
+            # Save output of the last cell
+            self.ipy_shell.user_ns['last_output'] = output
+
             # Send images, if any
             for filename in image_filenames:
                 try:


### PR DESCRIPTION
Save the outputs of every cell in a file in order to be able to inspect it in the test cell.

Anaconda team needed it.